### PR TITLE
fix: change the python36 images

### DIFF
--- a/dockers/smartkg_services/aspnetcore/Dockerfile
+++ b/dockers/smartkg_services/aspnetcore/Dockerfile
@@ -1,4 +1,4 @@
-FROM python36
+FROM podshumok/python36
 
 COPY aspnetcore-runtime-2.1.16-linux-x64.tar.gz /data/
 


### PR DESCRIPTION
when following the [instruction](https://github.com/microsoft/SmartKG/blob/master/SmartKG_Spec.pdf) to install SmratKG in ubuntu, I get the error as below:
![image](https://user-images.githubusercontent.com/31543505/128827136-fea60185-e9bf-4523-ae01-0880e8502086.png)
After google, I suppose it may be there is no python36 image name, so I change the python36 image name(podshumok/python36), and this images is a popular python36 image.
![image](https://user-images.githubusercontent.com/31543505/128827413-7ae97a1d-a0e2-468a-b079-e61b5e1125ee.png)
